### PR TITLE
[Anon] File update: (HH) Solar Auxilia - Crusade Army List.cat

### DIFF
--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -4569,7 +4569,7 @@
                     <cost name="pts" costTypeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="b5b5bc53-02f0-596c-28ec-7e659ce2e981" name="Quad Mortar" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                <selectionEntry id="b5b5bc53-02f0-596c-28ec-7e659ce2e981" name="Quad Mortar (frag &amp; shatter shells)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
                   <infoLinks/>


### PR DESCRIPTION
**File:** (HH) Solar Auxilia - Crusade Army List.cat

**Description:** Auxilia Rapier Battery option: Quad mortar, 25 points each;   It should be Quad mortar (frag & shatter shells), 35 points each.

From the Crusade Imperialis red book.